### PR TITLE
Fix tester colors

### DIFF
--- a/tester/run-tests.sh
+++ b/tester/run-tests.sh
@@ -39,7 +39,7 @@ print_error_message () {
     local testnum=$1
     local contrunning=$2
     local filetype=$3
-    builtin echo -e "\e[31mtest $testnum: $filetype incorrect\e[0m"
+    printf "\e[31mtest $testnum: $filetype incorrect\e[0m\n"
     echo "  what results should be found in file: $testdir/$testnum.$filetype"
     echo "  what results produced by your program: tests-out/$testnum.$filetype"
     echo "  compare the two using diff, cmp, or related tools to debug, e.g.:"
@@ -82,7 +82,7 @@ run_and_check () {
 	exit 0
     fi
     if (( $verbose == 1 )); then
-	echo -n -e "\e[33mrunning test $testnum: \e[0m"
+	printf "\e[33mrunning test $testnum: \e[0m\n"
 	cat $testdir/$testnum.desc
     fi
     run_test $testdir $testnum $verbose
@@ -95,7 +95,7 @@ run_and_check () {
     fi
     # echo "results: outcheck:$outcheck errcheck:$errcheck"
     if (( $rccheck == 0 )) && (( $outcheck == 0 )) && (( $errcheck == 0 )) && (( $othercheck == 0 )); then
-	builtin echo -e "\e[32mtest $testnum: passed\e[0m"
+	printf "\e[32mtest $testnum: passed\e[0m\n"
 	if (( $verbose == 1 )); then
 	    echo ""
 	fi
@@ -183,7 +183,7 @@ fi
 # do a one-time setup step
 if (( $skippre == 0 )); then
     if [[ -f tests/pre ]]; then
-	builtin echo -e "\e[33mdoing one-time pre-test\e[0m (use -s to suppress)"
+	printf "\e[33mdoing one-time pre-test\e[0m (use -s to suppress)\n"
 	source tests/pre
 	if (( $? != 0 )); then
 	    echo "pre-test: failed"


### PR DESCRIPTION
Running `./test-wcat.sh` in macOS prints the color escape characters instead of interpreting the color escape characters. See screenshot below:

<img width="682" alt="Screen Shot 2021-06-17 at 10 32 03 PM" src="https://user-images.githubusercontent.com/9835486/122511658-704fa080-cfbc-11eb-9856-7146ebe90e91.png">

Per https://stackoverflow.com/a/28782466:

> OSX ships with an old version of Bash that does not support the \e escape character

However, using `printf` instead of `echo` seems to solve the issue.

This commit replaces `echo` with `printf` where the string to print contains color escape characters.

**Note:** I am not a bash expert, and there may be a better way to solve this, so I'm open to suggestions.