### PR TITLE
avoid saving intermediate files on a public dir

### DIFF
--- a/processes-shell/tests/11.in
+++ b/processes-shell/tests/11.in
@@ -1,4 +1,4 @@
-ls tests/p2a-test>/tmp/output11
-cat /tmp/output11
-rm -f /tmp/output11
+ls tests/p2a-test>output11
+cat output11
+rm -f output11
 exit

--- a/processes-shell/tests/20.in
+++ b/processes-shell/tests/20.in
@@ -1,9 +1,9 @@
 path /bin tests
-p1.sh > /tmp/output201 & p2.sh > /tmp/output202 & p3.sh > /tmp/output203
-cat /tmp/output201
-cat /tmp/output202
-cat /tmp/output203
-rm -rf /tmp/output201
-rm -rf /tmp/output202
-rm -rf /tmp/output203
+p1.sh > output201 & p2.sh > output202 & p3.sh > output203
+cat output201
+cat output202
+cat output203
+rm -rf output201
+rm -rf output202
+rm -rf output203
 exit

--- a/processes-shell/tests/22.in
+++ b/processes-shell/tests/22.in
@@ -1,5 +1,5 @@
 path /bin tests
-p5.sh > /tmp/output22 & p4.sh > /tmp/output22
-cat /tmp/output22
-rm -f /tmp/output22
+p5.sh > output22 & p4.sh > output22
+cat output22
+rm -f output22
 exit


### PR DESCRIPTION
`/tmp` is a public directory for all users. When testing on a shared instructional machine, it happened that a student left an intermediate file `/tmp/output11`. It then caused other students to fail test case 11 due to permission denied for `rm -f /tmp/output11`. It might be a better idea to keep these intermediate files locally instead of under a shared directory.