### PR TITLE
fix : read and display the HTTP content properly

### DIFF
--- a/concurrency-webserver/src/wclient.c
+++ b/concurrency-webserver/src/wclient.c
@@ -59,10 +59,14 @@ void client_print(int fd) {
     }
     
     // Read and display the HTTP Body 
-    n = readline_or_die(fd, buf, MAXBUF);
-    while (n > 0) {
-	printf("%s", buf);
-	n = readline_or_die(fd, buf, MAXBUF);
+    int capacity = sizeof(buf) - 1;
+    n = read_or_die(fd, buf, capacity);
+    while (n > 0)
+    {
+        buf[n] = '\0';
+        printf("%s", buf);
+
+        n = read_or_die(fd, buf, capacity);
     }
 }
 


### PR DESCRIPTION
For file `wclient.c` in project `concurrency-webserver`, the method `read_or_die` instead of `readline_or_die` should be used to read the HTTP content. And for file size larger than 8K, we should also take care of the `buf` boundary.