### PR TITLE
correct instructions for initial-reverse

### DIFF
--- a/initial-reverse/README.md
+++ b/initial-reverse/README.md
@@ -65,7 +65,7 @@ Sounds easy, right? It should. But there are a few details...
 ## Assumptions and Errors
 
 - **Input is the same as output:** If the input file and output file are the
-same file, you should print out an error message "Input and output file must
+same file, you should print out an error message "reverse: input and output file must
 differ" and exit with return code 1.
 
 - **String length:** You may not assume anything about how long a line should
@@ -76,7 +76,7 @@ file, i.e., it may be **VERY** long.
 
 - **Invalid files:** If the user specifies an input file or output file, and
 for some reason, when you try to open said file (e.g., `input.txt`) and
-fail, you should print out the following exact error message: `error:
+fail, you should print out the following exact error message: `reverse:
 cannot open file 'input.txt'` and then exit with return code 1 (i.e., call
 `exit(1);`).
 


### PR DESCRIPTION
This PR corrects the instructions for the inital-reverse exercise so that they match the test logic (specifically, see [3.err](https://github.com/remzi-arpacidusseau/ostep-projects/blob/1979e863eb2e1394dc25773fd5caf19f4a8b9bff/initial-reverse/tests/3.err) and [4.err](https://github.com/remzi-arpacidusseau/ostep-projects/blob/1979e863eb2e1394dc25773fd5caf19f4a8b9bff/initial-reverse/tests/4.err)).

Thanks a lot for providing these exercises!