### PR TITLE
Make input and output files the same

### DIFF
--- a/initial-reverse/tests/5.run
+++ b/initial-reverse/tests/5.run
@@ -1,1 +1,1 @@
-./reverse tests/5.in tests-out/5.in
+./reverse tests/5.in tests/5.in


### PR DESCRIPTION
It says that only when input is the same that output the error "Input and output file must differ" should be printed (as expected in that test cases). But here input and output are two different files, and program should work successfully in that case. And to make testcase num.5 working that input should be updated.