### PR TITLE
Typo Fix

### DIFF
--- a/initial-utilities/README.md
+++ b/initial-utilities/README.md
@@ -107,7 +107,7 @@ as the second argument. Read the man pages to see what other options are
 available. 
 
 Second, note the *critical* checking of whether the **fopen()** actually
-succeeded. This is not Java where an exception will be thrown when things goes
+succeeded. This is not Java where an exception will be thrown when things go
 wrong; rather, it is C, and it is expected (in good programs, i.e., the
 only kind you'd want to write) that you always will check if the call
 succeeded. Reading the man page tells you the details of what is returned when

--- a/initial-utilities/README.md
+++ b/initial-utilities/README.md
@@ -147,7 +147,7 @@ printf("%s", buffer);
 Note that you should *not* add a newline (\\n) character to the printf(),
 because that would be changing the output of the file to have extra
 newlines. Just print the exact contents of the read-in buffer (which, of
-course, many include a newline).
+course, may include a newline).
 
 Finally, when you are done reading and printing, use **fclose()** to close the
 file (thus indicating you no longer need to read from it).


### PR DESCRIPTION
Incorrect conjugation of "to go".
"when things *goes wrong" --> "when things *go wrong"