### PR TITLE
Use qemu target in tester script instead of qemu-nox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Build artifacts
+*.o
+*.d
+*.img
+*.out
+
+# QEMU temporary files
+*.log
+
+# Editor/OS files
+.DS_Store
+*.swp
+
+# Dev container settings (if not shared)
+.devcontainer/
+

--- a/tester/run-xv6-command.exp
+++ b/tester/run-xv6-command.exp
@@ -13,7 +13,7 @@ proc shutdown {} {
 set timeout -1
 
 # build and launch xv6 on qemu
-spawn make [lindex $argv 0] -f [lindex $argv 1] qemu-nox
+spawn make [lindex $argv 0] -f [lindex $argv 1] qemu
 
 trap {
     shutdown


### PR DESCRIPTION
The xv6-riscv Makefile does not define a qemu-nox target, only qemu. Update tester/run-xv6-command.exp to invoke make qemu instead of make qemu-nox when launching xv6. This allows the tester to successfully build and run xv6 in QEMU without target errors.